### PR TITLE
Affine3d -> Isometry3d for Bionic

### DIFF
--- a/rtr_moveit/CMakeLists.txt
+++ b/rtr_moveit/CMakeLists.txt
@@ -12,6 +12,7 @@ add_definitions(-W -Wall -Wextra
 
 # Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
+  eigen_conversions
   geometry_msgs
   moveit_core
   moveit_msgs
@@ -37,6 +38,7 @@ find_package(Eigen3 REQUIRED)
 ###################################
 catkin_package(
   CATKIN_DEPENDS
+    eigen_conversions
     moveit_core
     pluginlib
     roscpp

--- a/rtr_moveit/package.xml
+++ b/rtr_moveit/package.xml
@@ -14,6 +14,7 @@
   <build_depend version_gte="1.0.0">rtr-core</build_depend>
   <build_depend version_gte="1.0.0">rtr-occupancy</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>eigen_conversions</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_msgs</build_depend>
@@ -31,6 +32,7 @@
   <exec_depend version_gte="1.0.0">rtr-core</exec_depend>
   <exec_depend version_gte="1.0.0">rtr-occupancy</exec_depend>
   <exec_depend>eigen</exec_depend>
+  <exec_depend>eigen_conversions</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>moveit_core</exec_depend>
   <exec_depend>moveit_msgs</exec_depend>

--- a/rtr_moveit/src/occupancy_handler.cpp
+++ b/rtr_moveit/src/occupancy_handler.cpp
@@ -166,13 +166,15 @@ bool OccupancyHandler::fromPlanningScene(const planning_scene::PlanningSceneCons
 
   // x/y/z translation steps, since relative movements are more efficient than repositioning the object
   auto volume_orientation = world_to_volume.rotation();
-  auto x_step(volume_orientation * Eigen::Translation3d(x_voxel_dimension, 0, 0));
-  auto y_step(volume_orientation * Eigen::Translation3d(0, y_voxel_dimension, 0));
-  auto z_step(volume_orientation * Eigen::Translation3d(0, 0, z_voxel_dimension));
+  auto x_step(volume_orientation * decltype(world_to_volume)(Eigen::Translation3d(x_voxel_dimension, 0, 0)));
+  auto y_step(volume_orientation * decltype(world_to_volume)(Eigen::Translation3d(0, y_voxel_dimension, 0)));
+  auto z_step(volume_orientation * decltype(world_to_volume)(Eigen::Translation3d(0, 0, z_voxel_dimension)));
 
   // x/y reset transforms
-  auto y_reset(volume_orientation * Eigen::Translation3d(0, -y_voxels * y_voxel_dimension, 0));
-  auto z_reset(volume_orientation * Eigen::Translation3d(0, 0, -z_voxels * z_voxel_dimension));
+  auto y_reset(volume_orientation *
+               decltype(world_to_volume)(Eigen::Translation3d(0, -y_voxels * y_voxel_dimension, 0)));
+  auto z_reset(volume_orientation *
+               decltype(world_to_volume)(Eigen::Translation3d(0, 0, -z_voxels * z_voxel_dimension)));
 
   // Loop over X/Y/Z voxel positions and check for box collisions in the collision scene
   // NOTE: This implementation is a prototype and will be replaced by more efficient methods as described below


### PR DESCRIPTION
Uses `decltype` to switch between `Affine3d` and `Isometry3d`.

Builds on both Xenial/Kinetic and Bionic/Melodic.

Unit tests are passing, but I haven't tested the tutorial yet.